### PR TITLE
Fix Issue#6 for Azure expRoute required pub/fix IP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 #  Local .terraform directories
 **/.terraform/*
+.terraform*
 
 # .tfstate files
 *.tfstate
@@ -18,3 +19,6 @@ secret_env_vars
 ######################
 .DS_Store
 .DS_Store?
+
+#Infracost for Azure cost estimate
+.infracost

--- a/new-environment/network-azure.tf
+++ b/new-environment/network-azure.tf
@@ -39,7 +39,8 @@ resource "azurerm_public_ip" "gateway_public_ip" {
   location            = azurerm_resource_group.resource_group.location
   resource_group_name = azurerm_resource_group.resource_group.name
 
-  allocation_method = "Dynamic"
+  allocation_method = "Static"
+  sku = "Standard"
 }
 
 # ------ Create Azure Compute VM Public IP

--- a/new-environment/terraform.tfvars.template
+++ b/new-environment/terraform.tfvars.template
@@ -10,5 +10,6 @@ private_key_path     = "~/<dir>/oci.pem"
 
 # ------ Azure Required Variables
 bandwidth="1000"
+# See # See https://learn.microsoft.com/en-us/azure/expressroute/expressroute-locations-providers for region and peering location name for region and peering location name
 azure_region="West US"
 peering_location="Washington DC"


### PR DESCRIPTION
Hi, I fixed the problem for issue#6. Just need to change line 42 of new-enviornment/network-azure.tf allocation_method from Dynamic to Static and add sku of Standard because sku standard requires static allocation and the new virtual_network_gateway doesn't allow SKU basic for public IP any more. The other changes is to ignore terraform lock file and file that created locally by my infracost extension on VS studio that can be ignored if you don't want them.
Let me know if you need anything.
Thanks
Albert